### PR TITLE
Timedout failed withdraw fix

### DIFF
--- a/bridge-backend/src/BridgeModule.ts
+++ b/bridge-backend/src/BridgeModule.ts
@@ -38,7 +38,7 @@ export class BridgeModule implements Module {
             RINKEBY:
               env("TOKEN_BRDIGE_CONTRACT_RINKEBY") || GLOBAL_BRIDGE_CONTRACT,
             BSC:
-              env("TOKEN_BRDIGE_CONTRACT_BSC_TESTNET") ||
+              env("TOKEN_BRDIGE_CONTRACT_BSC") ||
               GLOBAL_BRIDGE_CONTRACT,
             BSC_TESTNET:
               env("TOKEN_BRDIGE_CONTRACT_BSC_TESTNET") ||

--- a/bridge-backend/src/TokenBridgeService.ts
+++ b/bridge-backend/src/TokenBridgeService.ts
@@ -385,10 +385,10 @@ export class TokenBridgeService
       "Withdraw item with the provided id not found."
     );
     const pendingTxs = (item.useTransactions || []).filter(
-      (t) => t.status === "pending"
+      (t) => t.status === "pending" || t.status === "failed"
     );
     if (!pendingTxs.length && item.used === "pending") {
-      item.used = "failed";
+      item.used = "pending";
     }
     for (const tx of pendingTxs) {
       const txStatus = await this.helper.getTransactionStatus(
@@ -400,7 +400,7 @@ export class TokenBridgeService
       console.log(
         `Updating status for withdraw item ${id}: ${item.sendNetwork} ${txStatus}-${tx.id}`
       );
-      if (txStatus === ("timedout" || "failed")) {
+      if (txStatus === ("failed")) {
         item.used = "failed";
       } else if (txStatus === "successful") {
         item.used = "completed";

--- a/common-containers/src/chain/ChainEventItem.tsx
+++ b/common-containers/src/chain/ChainEventItem.tsx
@@ -99,7 +99,7 @@ export function ChainEventItem(props: ChainEventItemProps) {
     const dispatch = useDispatch();
     const {network, id, initialStatus, updater} = props;
     useEffect(() => {
-        if ((initialStatus === '' || initialStatus === 'pending') && !!network && !!id) {
+        if (((initialStatus === 'pending') && !!network && !!id) || initialStatus === 'failed') {
             dispatch(chainEventsSlice.actions.watchEvent({...props}));
         }
         // if (myEvent && (myEvent?.status !== 'pending' && myEvent?.status !== ''


### PR DESCRIPTION
**Summary**
- changes timed-out transactions from setting as failed to pending
- added failed transactions to event to be tracked by chain event tracker to update status.