### PR TITLE
SideBar logo and switch network fix

### DIFF
--- a/bridge-frontend/src/components/SidePanel.scss
+++ b/bridge-frontend/src/components/SidePanel.scss
@@ -12,6 +12,11 @@
     flex-direction: row;
     align-items: center;
     justify-content: flex-start;
+
+
+    .token-logo {
+        width: 40px;
+    }
 }
 
 .withdraw-item-head * {

--- a/bridge-frontend/src/components/SidePanel.tsx
+++ b/bridge-frontend/src/components/SidePanel.tsx
@@ -32,7 +32,7 @@ import { Actions as MainPageAction } from './../pages/Main/Main';
 //@ts-ignore
 import { AddTokenToMetamask } from 'component-library';
 import { CrossSwapClient } from '../clients/CrossSwapClient';
-import './SidePanel.css';
+import './SidePanel.scss';
 import { TokenLogo } from './TokenLogo';
 
 interface WithdrawSuccessMessage {

--- a/bridge-frontend/src/pages/Main/Main.tsx
+++ b/bridge-frontend/src/pages/Main/Main.tsx
@@ -441,17 +441,12 @@ export const ConnectBridge = () => {
                                             pageProps.itemId,
                                             onWithdrawSuccessMessage,
                                             onMessage, (v) => dispatch(Actions.setProgressStatus({ status: v })))}
-                                disabled={swapping || ((pageProps.network != pageProps.swapWithdrawNetwork) && pageProps.destNetwork === ('RINKEBY' || 'ETHEREUM'))}
+                                disabled={swapping}
                                 className="btn btn-pri action btn-icon btn-connect mt-4"
                             >
                                 <i className="mdi mdi-arrow-collapse"></i>{(pageProps.network != pageProps.swapWithdrawNetwork) ? 'Switch Network' : 'Withdraw'}
                             </Button>
-                            {
-                                ((pageProps.network != pageProps.swapWithdrawNetwork) && pageProps.destNetwork === ('RINKEBY' || 'ETHEREUM')) &&
-                                <p style={{ ...styles.manualNote }}>
-                                    <Alert message={`Manually Switch your Network to ${pageProps.destNetwork} from Metamask`} type="warning" showIcon />
-                                </p>
-                            }
+                
                         </div>
                     )
                 }

--- a/bridge-frontend/src/pages/Main/handler.ts
+++ b/bridge-frontend/src/pages/Main/handler.ts
@@ -20,6 +20,16 @@ export const changeNetwork = async (dispatch: Dispatch<AnyAction>,
         // @ts-ignore
         if (window.ethereum) {
             //@ts-ignore
+            const tx = await ethereum.request({method: 'wallet_switchEthereumChain', params:[ {"chainId": `0x${net.chainId}`}]});
+        }else{
+            dispatch(addAction(CommonActions.ERROR_OCCURED, {message:'Switch Network unavaialable, manually switch network on metamask' }));
+        }
+    } catch (e) {
+        try{
+            //try legacy request as temporary fallback, to be removed once wallet_switchEthereumChain is stable
+            //@ts-ignore
+            let ethereum = window.ethereum;
+            const net = Networks.for(network);
             const data = [ {
                 "chainId": net.chainId,
                 "chainName": net.displayName,
@@ -34,11 +44,10 @@ export const changeNetwork = async (dispatch: Dispatch<AnyAction>,
             }]
             /* eslint-disable */
             const tx = await ethereum.request({method: 'wallet_addEthereumChain', params:data})
-        }else{
-            dispatch(addAction(CommonActions.ERROR_OCCURED, {message:'Switch Network unavaialable, manually switch network on metamask' }));
+        }catch(e){
+            dispatch(addAction(CommonActions.ERROR_OCCURED, {message:'Switch Network unavaialable on Browser, manually switch network on metamask' }));
+            return
         }
-    } catch (e) {
-		dispatch(addAction(CommonActions.ERROR_OCCURED, {message:'Switch Network unavaialable on Browser, manually switch network on metamask' }));
     } finally {
         dispatch(addAction(CommonActions.WAITING_DONE, { source: 'dashboard' }));
     }


### PR DESCRIPTION
**What does this PR do?**
- Sets a defined width for the sidebar logo to avoid the overflow experienced in the withdrawal siderbar
- fixes the switch network button to implement the new `wallet_switchEthereumChain` rpc call to avoid need for manual switching.